### PR TITLE
make KeepAspectRatio works on NX

### DIFF
--- a/switch/pal_utils.c
+++ b/switch/pal_utils.c
@@ -201,6 +201,16 @@ UTIL_GetScreenSize(
 	DWORD *pdwScreenHeight
 )
 {
+	if( gConfig.fKeepAspectRatio ) {
+		SDL_DisplayMode DM;
+		int ret = SDL_GetCurrentDisplayMode(0, &DM);
+		if(ret == 0){
+			*pdwScreenWidth = DM.w;
+			*pdwScreenHeight = DM.h;
+		}
+		return ret == 0;
+	}
+	else
 	return FALSE;
 }
 
@@ -212,11 +222,16 @@ UTIL_IsAbsolutePath(
 	return FALSE;
 }
 
+void LOG_to_stdio(LOGLEVEL level, const char *full_log, const char *user_log){
+       printf(full_log);
+}
+
 int UTIL_Platform_Startup(
 	int argc,
 	char* argv[]
 )
 {
+	//UTIL_LogAddOutputCallback(LOG_to_stdio, gConfig.iLogLevel);
 	return 0;
 }
 


### PR DESCRIPTION
Previous in https://github.com/usineur/sdlpal/issues/6 I just made a patch for KeepAspectRatio to work, but it only works on EnableGLSL=1 situation; In this PR I've changed implementation method, makes it works on either.
Since the implementation will use native resolution( on switch handheld=720P, docked=1080P) instead of default 640x480, this patch will only change behavior when KeepAspectRatio=1.